### PR TITLE
Update Vue plugins to Vue 3 syntax

### DIFF
--- a/src/components/NotificationPlugin/index.js
+++ b/src/components/NotificationPlugin/index.js
@@ -1,6 +1,7 @@
 import Notifications from "./Notifications.vue";
+import { reactive } from 'vue';
 
-const NotificationStore = {
+const NotificationStore = reactive({
   state: [], // here the notifications will be added
   settings: {
     overlap: false,
@@ -42,23 +43,13 @@ const NotificationStore = {
       this.addNotification(notification);
     }
   },
-};
+});
 
 const NotificationsPlugin = {
-  install(Vue, options) {
-    let app = new Vue({
-      data: {
-        notificationStore: NotificationStore,
-      },
-      methods: {
-        notify(notification) {
-          this.notificationStore.notify(notification);
-        },
-      },
-    });
-    Vue.prototype.$notify = app.notify;
-    Vue.prototype.$notifications = app.notificationStore;
-    Vue.component("Notifications", Notifications);
+  install(app, options) {
+    app.config.globalProperties.$notify = NotificationStore.notify.bind(NotificationStore);
+    app.config.globalProperties.$notifications = NotificationStore;
+    app.component("Notifications", Notifications);
     if (options) {
       NotificationStore.setOptions(options);
     }
@@ -66,3 +57,4 @@ const NotificationsPlugin = {
 };
 
 export default NotificationsPlugin;
+

--- a/src/components/SidebarPlugin/index.js
+++ b/src/components/SidebarPlugin/index.js
@@ -1,26 +1,22 @@
 import Sidebar from "./SideBar.vue";
 import SidebarLink from "./SidebarLink";
+import { reactive } from 'vue'
 
-const SidebarStore = {
+const SidebarStore = reactive({
   showSidebar: false,
   sidebarLinks: [],
   displaySidebar(value) {
     this.showSidebar = value;
   },
-};
+});
 
 const SidebarPlugin = {
-  install(Vue) {
-    let app = new Vue({
-      data: {
-        sidebarStore: SidebarStore,
-      },
-    });
-
-    Vue.prototype.$sidebar = app.sidebarStore;
-    Vue.component("side-bar", Sidebar);
-    Vue.component("sidebar-link", SidebarLink);
+  install(app) {
+    app.config.globalProperties.$sidebar = SidebarStore;
+    app.component("side-bar", Sidebar);
+    app.component("sidebar-link", SidebarLink);
   },
 };
 
 export default SidebarPlugin;
+

--- a/src/plugins/RTLPlugin.js
+++ b/src/plugins/RTLPlugin.js
@@ -1,39 +1,36 @@
-export default {
-  install(Vue) {
-    let app = new Vue({
-      data() {
-        return {
-          isRTL: false,
-        };
-      },
-      methods: {
-        getDocClasses() {
-          return document.body.classList;
-        },
-        enableRTL() {
-          this.isRTL = true;
-          this.getDocClasses().add("rtl");
-          this.getDocClasses().add("menu-on-right");
-          this.toggleBootstrapRTL(true);
-        },
-        disableRTL() {
-          this.isRTL = false;
-          this.getDocClasses().remove("rtl");
-          this.getDocClasses().remove("menu-on-right");
-          this.toggleBootstrapRTL(false);
-        },
-        toggleBootstrapRTL(value) {
-          for (let i = 0; i < document.styleSheets.length; i++) {
-            let styleSheet = document.styleSheets[i];
-            let { href } = styleSheet;
-            if (href && href.endsWith("bootstrap-rtl.css")) {
-              styleSheet.disabled = !value;
-            }
-          }
-        },
-      },
-    });
+import { reactive } from 'vue'
 
-    Vue.prototype.$rtl = app;
+const rtlState = reactive({
+  isRTL: false,
+  getDocClasses() {
+    return document.body.classList;
+  },
+  enableRTL() {
+    this.isRTL = true;
+    this.getDocClasses().add("rtl");
+    this.getDocClasses().add("menu-on-right");
+    this.toggleBootstrapRTL(true);
+  },
+  disableRTL() {
+    this.isRTL = false;
+    this.getDocClasses().remove("rtl");
+    this.getDocClasses().remove("menu-on-right");
+    this.toggleBootstrapRTL(false);
+  },
+  toggleBootstrapRTL(value) {
+    for (let i = 0; i < document.styleSheets.length; i++) {
+      let styleSheet = document.styleSheets[i];
+      let { href } = styleSheet;
+      if (href && href.endsWith("bootstrap-rtl.css")) {
+        styleSheet.disabled = !value;
+      }
+    }
+  },
+});
+
+export default {
+  install(app) {
+    app.config.globalProperties.$rtl = rtlState;
   },
 };
+

--- a/src/plugins/blackDashboard.js
+++ b/src/plugins/blackDashboard.js
@@ -10,11 +10,12 @@ import "@/assets/css/nucleo-icons.css";
 import "@/assets/demo/demo.css";
 
 export default {
-  install(Vue) {
-    Vue.use(GlobalComponents);
-    Vue.use(GlobalDirectives);
-    Vue.use(SideBar);
-    Vue.use(Notify);
-    Vue.use(RTLPlugin);
+  install(app) {
+    app.use(GlobalComponents);
+    app.use(GlobalDirectives);
+    app.use(SideBar);
+    app.use(Notify);
+    app.use(RTLPlugin);
   },
 };
+

--- a/src/plugins/globalComponents.js
+++ b/src/plugins/globalComponents.js
@@ -10,13 +10,14 @@ import {
  */
 
 const GlobalComponents = {
-  install(Vue) {
-    Vue.component(BaseInput.name, BaseInput);
-    Vue.component(Card.name, Card);
-    Vue.component(BaseDropdown.name, BaseDropdown);
-    Vue.component(BaseButton.name, BaseButton);
-    Vue.component(BaseCheckbox.name, BaseCheckbox);
+  install(app) {
+    app.component(BaseInput.name, BaseInput);
+    app.component(Card.name, Card);
+    app.component(BaseDropdown.name, BaseDropdown);
+    app.component(BaseButton.name, BaseButton);
+    app.component(BaseCheckbox.name, BaseCheckbox);
   },
 };
 
 export default GlobalComponents;
+

--- a/src/plugins/globalDirectives.js
+++ b/src/plugins/globalDirectives.js
@@ -5,9 +5,10 @@ import clickOutside from "../directives/click-ouside.js";
  */
 
 const GlobalDirectives = {
-  install(Vue) {
-    Vue.directive("click-outside", clickOutside);
+  install(app) {
+    app.directive("click-outside", clickOutside);
   },
 };
 
 export default GlobalDirectives;
+


### PR DESCRIPTION
This PR updates all Vue plugins to use Vue 3 syntax:

- Updated SidebarPlugin to use Vue 3 composition API
- Updated BlackDashboard plugin to use Vue 3 app.use
- Updated GlobalComponents to use Vue 3 app.component
- Updated GlobalDirectives to use Vue 3 app.directive
- Updated RTLPlugin to use Vue 3 reactive and globalProperties
- Updated NotificationPlugin to use Vue 3 reactive and globalProperties